### PR TITLE
Replace commit with version in node stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dev:sync_nodes": "yarn sync_nodes -o output/nodes.json -e dev",
     "local:sync_nodes": "yarn sync_nodes -o output/nodes.json --rpc http://localhost:8545 --headcontract 0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84",
     "challenge_stats": "ts-node src/challenge_stats.ts",
-    "test:challenge_stats": "ts-node src/challenge_stats.ts -o output/challenges.json -e test",
+    "test:challenge_stats": "node --max_old_space_size=8192 -r ts-node/register src/challenge_stats.ts -o output/challenges.json -e test",
     "dev:challenge_stats": "ts-node src/challenge_stats.ts -o output/challenges.json -e dev",
     "local:challenge_stats": "ts-node src/challenge_stats.ts -o output/challenges.json -e test --rpc http://localhost:8545 --headcontract 0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84",
     "lint": "tslint 'src/**/*.ts' --fix",

--- a/src/sync_nodes.ts
+++ b/src/sync_nodes.ts
@@ -5,7 +5,7 @@ import fetch from 'node-fetch';
 import {sortChronologically, convertRoleCodeToRoleName, convertWeiToAmber} from './utils/event_utils';
 
 const NODE_FETCH_TIMEOUT = 2000;
-const NODE_LOGS_ACTIVE_TIMEOUT = 60000;
+const NODE_LOGS_ACTIVE_TIMEOUT = 600000;
 
 const getNodeState = async ({url}): Promise<{ version: string, isActive: boolean }> => {
   try {


### PR DESCRIPTION
To list all not working atlases: 
`yarn test:sync_nodes && yarn to_csv output/nodes.json | grep ATLAS | awk -F ',' '{print($5" "$2" "$6)}' | grep -v true`